### PR TITLE
Add autoCloseDisabled attribute

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -92,7 +92,7 @@ Fired when the `paper-toast` has completely closed.
 
   <link rel="stylesheet" href="paper-toast.css" >
 
-  <core-overlay id="overlay" autoFocusDisabled autoCloseDisabled={{autoCloseDisabled}} opened="{{opened}}" target="{{}}" transition="core-transition-bottom"></core-overlay>
+  <core-overlay id="overlay" autoFocusDisabled autoCloseDisabled="{{autoCloseDisabled}}" opened="{{opened}}" target="{{}}" transition="core-transition-bottom"></core-overlay>
 
   <div class="toast-container" horizontal layout>
 


### PR DESCRIPTION
The autoCloseDisabled attribute from core-overlay should be exported by paper-toast. If set, toasts do not automatically disappear after interacting with other elements on the page. Toasts would still disappear if they are closed manually or after the proper timeout.

The original and default behaviors of paper-toast are unchanged with this pull request.
